### PR TITLE
Prevent redirects by filtering the SQL queries

### DIFF
--- a/polylang-slug.php
+++ b/polylang-slug.php
@@ -104,6 +104,44 @@ function polylang_slug_unique_slug_in_language( $slug, $post_ID, $post_status, $
 add_filter( 'wp_unique_post_slug', 'polylang_slug_unique_slug_in_language', 10, 6 );
 
 /**
+ * Modify the sql query to include checks for the current language
+ *
+ * @since 0.1.0
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ * @global StdClass $polylang
+ *
+ * @param string $query Database query.
+ */
+function polylang_slug_filter_queries( $query ) {
+	global $wpdb, $polylang;
+	// keep a record of the queries
+	$queries[] = $query;
+
+	$is_main_sql = preg_match( "#\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM {$wpdb->posts}\n\t\tWHERE post_name IN \(([^)]+)\)\n\t\tAND post_type IN \(([^)]+)\)#", $query, $matches );
+
+	if ( $is_main_sql ) {
+
+		$lang = pll_current_language();
+
+		// " INNER JOIN $wpdb->term_relationships AS pll_tr ON pll_tr.object_id = " . ('term' == $type ? "t.term_id" : "ID");
+		$join_clause  = $polylang->model->join_clause( 'post' );
+		// " AND pll_tr.term_taxonomy_id IN (" . implode(',', $languages) . ")"
+		$where_clause = $polylang->model->where_clause( $lang, 'post' );
+
+		$query = "SELECT ID, post_name, post_parent, post_type
+				FROM {$wpdb->posts}
+				$join_clause
+				WHERE post_name IN ({$matches[1]})
+				AND post_type IN ({$matches[2]})
+				$where_clause";
+	}
+
+	return $query;
+}
+add_filter( 'query', 'polylang_slug_filter_queries' );
+
+/**
  * Extend the WHERE clause of the query
  *
  * This allows the query to return only the posts of the current language

--- a/polylang-slug.php
+++ b/polylang-slug.php
@@ -112,13 +112,18 @@ add_filter( 'wp_unique_post_slug', 'polylang_slug_unique_slug_in_language', 10, 
  * @global StdClass $polylang
  *
  * @param string $query Database query.
+ *
+ * @return string The modified query
  */
 function polylang_slug_filter_queries( $query ) {
 	global $wpdb, $polylang;
 	// keep a record of the queries
 	$queries[] = $query;
 
-	$is_main_sql = preg_match( "#\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM {$wpdb->posts}\n\t\tWHERE post_name IN \(([^)]+)\)\n\t\tAND post_type IN \(([^)]+)\)#", $query, $matches );
+	$is_main_sql = preg_match(
+		"#SELECT ID, post_name, post_parent, post_type FROM {$wpdb->posts} WHERE post_name IN \(([^)]+)\) AND post_type IN \(([^)]+)\)#",
+		trim(str_replace(array("\t", "\n"), array( '', ' ' ), $query)),
+		$matches );
 
 	if ( $is_main_sql ) {
 


### PR DESCRIPTION
This reintroduces the `polylang_slug_filter_queries` function to allow for `/fr/blog`, `/it/blog` and of course `/blog/`.

This should fix #5 (and maybe even #1?).
