### PR TITLE
Check if `$lang` is not false before setting the where clause

### DIFF
--- a/polylang-slug.php
+++ b/polylang-slug.php
@@ -127,7 +127,10 @@ function polylang_slug_filter_queries( $query ) {
 		// " INNER JOIN $wpdb->term_relationships AS pll_tr ON pll_tr.object_id = " . ('term' == $type ? "t.term_id" : "ID");
 		$join_clause  = $polylang->model->join_clause( 'post' );
 		// " AND pll_tr.term_taxonomy_id IN (" . implode(',', $languages) . ")"
-		$where_clause = $polylang->model->where_clause( $lang, 'post' );
+		$where_clause = '';
+		if ( $lang ) {
+			$where_clause = $polylang->model->where_clause( $lang, 'post' );
+		}
 
 		$query = "SELECT ID, post_name, post_parent, post_type
 				FROM {$wpdb->posts}


### PR DESCRIPTION
Sounds like a bug in Polylang which isn't fully checked against in this plugin.

`pll_current_language` can return false. If that's the case, the where clause can't be properly generated in the `polylang_slug_filter_queries` function.
