### PR TITLE
Fix comparison operator in version_compare() calls

### DIFF
--- a/polylang-slug.php
+++ b/polylang-slug.php
@@ -28,7 +28,7 @@
 // Built using code from: https://wordpress.org/support/topic/plugin-polylang-identical-page-names-in-different-languages?replies=8#post-2669927
 
 // Check if PLL exists & the minimum version is correct.
-if ( ! defined( 'POLYLANG_VERSION' ) || version_compare( POLYLANG_VERSION, '1.7', '=<' ) || version_compare( $GLOBALS[ 'wp_version' ], '4.0', '=<' ) ) {
+if ( ! defined( 'POLYLANG_VERSION' ) || version_compare( POLYLANG_VERSION, '1.7', '<=' ) || version_compare( $GLOBALS[ 'wp_version' ], '4.0', '<=' ) ) {
 	add_action( 'admin_notices', 'polylang_slug_admin_notices' );
 	return;
 }


### PR DESCRIPTION
Wrong operator throws a fatal error on PHP 8 and newer.

Fixes #51.
Fixes #52.